### PR TITLE
Change the int/pointer casts to use memcpy.

### DIFF
--- a/imgui-SFML.cpp
+++ b/imgui-SFML.cpp
@@ -555,7 +555,8 @@ void Image(const sf::Texture& texture,
 void Image(const sf::Texture& texture, const sf::Vector2f& size,
     const sf::Color& tintColor, const sf::Color& borderColor)
 {
-    ImGui::Image(convertGLTextureHandleToImTextureID(texture.getNativeHandle()), size, ImVec2(0, 0), ImVec2(1, 1), tintColor, borderColor);
+    ImTextureID textureID = convertGLTextureHandleToImTextureID(texture.getNativeHandle());
+    ImGui::Image(textureID, size, ImVec2(0, 0), ImVec2(1, 1), tintColor, borderColor);
 }
 
 void Image(const sf::Texture& texture, const sf::FloatRect& textureRect,
@@ -571,7 +572,9 @@ void Image(const sf::Texture& texture, const sf::Vector2f& size, const sf::Float
     ImVec2 uv0(textureRect.left / textureSize.x, textureRect.top / textureSize.y);
     ImVec2 uv1((textureRect.left + textureRect.width) / textureSize.x,
         (textureRect.top + textureRect.height) / textureSize.y);
-    ImGui::Image(convertGLTextureHandleToImTextureID(texture.getNativeHandle()), size, uv0, uv1, tintColor, borderColor);
+
+    ImTextureID textureID = convertGLTextureHandleToImTextureID(texture.getNativeHandle());
+    ImGui::Image(textureID, size, uv0, uv1, tintColor, borderColor);
 }
 
 void Image(const sf::Sprite& sprite,
@@ -748,7 +751,8 @@ void RenderDrawLists(ImDrawData* draw_data)
             if (pcmd->UserCallback) {
                 pcmd->UserCallback(cmd_list, pcmd);
             } else {
-                glBindTexture(GL_TEXTURE_2D, convertImTextureIDToGLTextureHandle(pcmd->TextureId));
+                GLuint textureHandle = convertImTextureIDToGLTextureHandle(pcmd->TextureId);
+                glBindTexture(GL_TEXTURE_2D, textureHandle);
                 glScissor((int)pcmd->ClipRect.x, (int)(fb_height - pcmd->ClipRect.w),
                     (int)(pcmd->ClipRect.z - pcmd->ClipRect.x), (int)(pcmd->ClipRect.w - pcmd->ClipRect.y));
                 glDrawElements(GL_TRIANGLES, (GLsizei)pcmd->ElemCount, GL_UNSIGNED_SHORT, idx_buffer);
@@ -775,7 +779,8 @@ bool imageButtonImpl(const sf::Texture& texture, const sf::FloatRect& textureRec
     ImVec2 uv1((textureRect.left + textureRect.width)  / textureSize.x,
                (textureRect.top  + textureRect.height) / textureSize.y);
 
-    return ImGui::ImageButton(convertGLTextureHandleToImTextureID(texture.getNativeHandle()), size, uv0, uv1, framePadding, bgColor, tintColor);
+    ImTextureID textureID = convertGLTextureHandleToImTextureID(texture.getNativeHandle());
+    return ImGui::ImageButton(textureID, size, uv0, uv1, framePadding, bgColor, tintColor);
 }
 
 unsigned int getConnectedJoystickId()


### PR DESCRIPTION
- Add a static_assert to make sure we can safely put GLuint texture IDs into the ImTextureID (currently void*). Should catch cases where, _somehow_, GLuint is larger than the pointer size on the target system (and thus trying to use it for texture IDs would likely lead to memory corruption).

- Use memcpy to transfer data in and out of ImGui's texture IDs rather than cast. This method of type-punning is safe in regards to strict-aliasing (there was potential UB due to strict-aliasing rules at the original file's line 736, pointed out by `-Wstrict-aliasing`). It also allows us to remove the int-to-pointer cast warning suppression.

Code generated with optimisations should be identical or near identical as modern compilers recognise memcpy as a commonly used method of type-punning.