### PR TITLE
Upgrade to new enough CMake to avoid deprecation notices

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.1)
+cmake_minimum_required(VERSION 3.10)
 
 project(imgui_sfml
   LANGUAGES CXX


### PR DESCRIPTION
As of CMake 3.27 I'm getting the following error when configuring ImGui-SFML

```
CMake Deprecation Warning at build/_deps/imgui-sfml-src/CMakeLists.txt:1 (cmake_minimum_required):
  Compatibility with CMake < 3.5 will be removed from a future version of
  CMake.

  Update the VERSION argument <min> value or use a ...<max> suffix to tell
  CMake that the project does not need compatibility with older versions.
```

CMake 3.1 is VERY old at this point in the year 2023 and it's safe to assume that noboby is using a CMake version older than 3.10 or perhaps even 3.16.