### PR TITLE
Add and fix compiler warnings

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -44,7 +44,7 @@ if (IMGUI_SFML_FIND_SFML)
   find_package(SFML 2.5 COMPONENTS graphics system window)
 
   if(NOT SFML_FOUND)
-    message(FATAL_ERROR "SFML 2 directory not found. Set SFML_DIR to directory where SFML was built (or one which ccontains SFMLConfig.cmake)")
+    message(FATAL_ERROR "SFML 2 directory not found. Set SFML_DIR to directory where SFML was built (or one which contains SFMLConfig.cmake)")
   endif()
 endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -131,6 +131,12 @@ target_compile_definitions(ImGui-SFML
     IMGUI_USER_CONFIG="${IMGUI_SFML_CONFIG_NAME}"
 )
 
+if(MSVC)
+  target_compile_options(ImGui-SFML PRIVATE /W3)
+elseif(CMAKE_CXX_COMPILER_ID MATCHES "(GNU|Clang)")
+  target_compile_options(ImGui-SFML PRIVATE -Werror -Wall -Wextra -Wpedantic -Wshadow)
+endif()
+
 if(WIN32 AND MINGW)
   target_link_libraries(ImGui-SFML PUBLIC imm32)
 endif()

--- a/imgui-SFML.cpp
+++ b/imgui-SFML.cpp
@@ -25,6 +25,10 @@
 #include <memory>
 #include <vector>
 
+#if defined(__APPLE__)
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+#endif
+
 #if SFML_VERSION_MAJOR >= 3
 #define IMGUI_SFML_KEY_APOSTROPHE sf::Keyboard::Apostrophe
 #define IMGUI_SFML_KEY_GRAVE sf::Keyboard::Grave


### PR DESCRIPTION
Silencing the OpenGL deprecation warnings was my first goal since they were cluttering up the console output. While I was in there I added a quick a few lines to add the most basic GCC and Clang warnings. I see a few other PRs are touching on compiler warnings as well so this helps lay the groundwork to add (and fix) more warnings in the future.

I also kept another commit that fixes a little typo I found a few days ago.