### PR TITLE
Reenable compiler warnings

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,6 +82,7 @@ jobs:
           -DCMAKE_BUILD_TYPE=${{matrix.type.name}} \
           -DIMGUI_DIR=$GITHUB_WORKSPACE/imgui \
           -DSFML_ROOT=$GITHUB_WORKSPACE/sfml/install \
+          -DIMGUI_SFML_WARNINGS_AS_ERRORS=ON \
           ${{matrix.platform.flags}} \
           ${{matrix.config.flags}}
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -131,6 +131,17 @@ target_compile_definitions(ImGui-SFML
     IMGUI_USER_CONFIG="${IMGUI_SFML_CONFIG_NAME}"
 )
 
+option(IMGUI_SFML_WARNINGS_AS_ERRORS "Treat compiler warnings as errors" OFF)
+if(MSVC)
+  target_compile_options(ImGui-SFML PRIVATE
+    $<$<BOOL:${IMGUI_SFML_WARNINGS_AS_ERRORS}>:/WX>
+    /W3)
+elseif(CMAKE_CXX_COMPILER_ID MATCHES "(GNU|Clang)")
+  target_compile_options(ImGui-SFML PRIVATE
+    $<$<BOOL:${IMGUI_SFML_WARNINGS_AS_ERRORS}>:-Werror>
+    -Wall -Wextra -Wpedantic -Wshadow)
+endif()
+
 if(WIN32 AND MINGW)
   target_link_libraries(ImGui-SFML PUBLIC imm32)
 endif()


### PR DESCRIPTION
Reverts #248. Compiler warnings a critical part of quickly writing safe and correct code. It's imperative we use this. This PR adds compiler warnings that are disabled by default and only enforced as hard errors in CI. This way it does not pose a risk of 3rd parties failing to build our code due to `/WX` or `-Werror` turning a warning into an error.