### PR TITLE
ImGui-SFML 2.6 release notes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.10)
 
 project(imgui_sfml
   LANGUAGES CXX
-  VERSION 2.5
+  VERSION 2.6
 )
 
 # In CMake 3.12+ this policy will automatically take the ImGui_ROOT and SFML_ROOT environment variables

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
-ImGui-SFML v2.5
-=======
+ImGui-SFML
+==========
 
 Library which allows you to use [Dear ImGui](https://github.com/ocornut/imgui) with [SFML](https://github.com/SFML/SFML)
 


### PR DESCRIPTION
Draft of release notes:

<blockquote>

Support the full key range from [imgui v1.87](https://github.com/ocornut/imgui/releases/tag/v1.87), e.g. `ImGui::IsKeyDown(ImGuiKey_Q)` now works (#197)
Expanded API: Propagate boolean error state from `Texture.create` to methods such as `Init` (#191)
Expanded API: Make all joystick axes and thresholds configurable, not just the left stick (#197)
API change: Fix typo in method names: "joytick" -> "joystick" (#201)
<!-- -->
Propagate window resize events to imgui (#222)
Fix dimming of imgui modal dialogs (004efd85a590343e8c9d166dc9d2524c199c9450)
Fix the window resize cursor not being shown on Windows (#193)
Fix memory leak from cursors (#194)
<!-- -->
Fix for changes in imgui around `ImGuiKey` (#219)
Fix deprecations from SFML 2.5/2.6 (#187, #205)
Fix for changes in upcoming SFML 3 (#205, #208, #217, #232, #250)
Fix various compiler warnings (#235, #245, #246)
<!-- -->
Raise C++ standard to C++11 (#203)
Raise CMake requirement from 3.1 to 3.10 (#244)

</blockquote>