### PR TITLE
Fix finding SFML 3 and add SFML 3 to CI pipeline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ concurrency:
 
 jobs:
   build:
-    name: ${{matrix.platform.name}} ${{matrix.config.name}} ${{matrix.type.name}}
+    name: ${{matrix.platform.name}} ${{matrix.config.name}} ${{matrix.type.name}} ${{matrix.sfml.name}}
     runs-on: ${{matrix.platform.os}}
     defaults:
       run:
@@ -31,6 +31,9 @@ jobs:
         type:
         - { name: Release }
         - { name: Debug }
+        sfml:
+        - { name: SFML v2, tag: 2.6.0 }
+        - { name: SFML v3, tag: master }
 
     steps:
     - name: Install Linux Dependencies
@@ -55,7 +58,7 @@ jobs:
       with:
         repository: SFML/SFML
         path: sfml
-        ref: 2.6.0
+        ref: ${{matrix.sfml.tag}}
 
     - name: Configure SFML
       run: |

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -41,7 +41,16 @@ if (IMGUI_SFML_FIND_SFML)
   if (NOT BUILD_SHARED_LIBS)
     set(SFML_STATIC_LIBRARIES ON)
   endif()
-  find_package(SFML 2.5 COMPONENTS graphics system window)
+  # Try to find SFML 2, else try to find SFML 3
+  find_package(SFML 2.5 COMPONENTS graphics window system)
+  if(SFML_FOUND)
+    set(SFML_TARGETS sfml-graphics sfml-window sfml-system)
+  else()
+    find_package(SFML 3 COMPONENTS Graphics Window System)
+    if(SFML_FOUND)
+      set(SFML_TARGETS SFML::Graphics SFML::Window SFML::System)
+    endif()
+  endif()
 
   if(NOT SFML_FOUND)
     message(FATAL_ERROR "SFML 2 directory not found. Set SFML_DIR to directory where SFML was built (or one which contains SFMLConfig.cmake)")
@@ -93,9 +102,7 @@ add_library(ImGui-SFML::ImGui-SFML ALIAS ImGui-SFML)
 
 target_link_libraries(ImGui-SFML
   PUBLIC
-    sfml-graphics
-    sfml-system
-    sfml-window
+    ${SFML_TARGETS}
     ${OPENGL_LIBRARIES}
 )
 


### PR DESCRIPTION
Currently in `master` it's not possible to find an installation of SFML 3. Using SFML 3 requires that someone already builds SFML 3 in their build tree and thus can't depend on a preexisting installation.

I then added SFML 3 to CI to ensure SFML 3 support is constantly maintained.