### PR TITLE
Implemented hovered state / use window events instead of global functions to query mouse state

### DIFF
--- a/imgui-SFML.cpp
+++ b/imgui-SFML.cpp
@@ -311,8 +311,10 @@ void ProcessEvent(const sf::Event& event) {
                                 static_cast<float>(event.mouseMove.y));
         s_currWindowCtx->mouseMoved = true;
         break;
+        default:
+            break;
     }
-    
+
     if (s_currWindowCtx->windowIsHovered) {
 
         switch (event.type) {
@@ -324,18 +326,17 @@ void ProcessEvent(const sf::Event& event) {
                 io.MouseWheelH += event.mouseWheelScroll.delta;
             }
             break;
-
+            default:
+                break;
         }
     }
 
-    if (s_currWindowCtx->windowHasFocus)
-    {
+    if (s_currWindowCtx->windowHasFocus) {
         switch (event.type) {
         case sf::Event::MouseButtonPressed: // fall-through
         case sf::Event::MouseButtonReleased: {
             const int button = event.mouseButton.button;
-            if (button >= 0 && button < 3)
-                {
+            if (button >= 0 && button < 3) {
                 if (event.type == sf::Event::MouseButtonPressed)
                 {
                     io.AddMouseButtonEvent(button, true);
@@ -440,8 +441,7 @@ void Update(const sf::Vector2i& mousePos, const sf::Vector2f& displaySize, sf::T
     io.DeltaTime = dt.asSeconds();
 
     if (s_currWindowCtx->windowIsHovered ||
-        s_currWindowCtx->windowHasFocus)
-    {
+        s_currWindowCtx->windowHasFocus) {
         if (io.WantSetMousePos) {
             const sf::Vector2i newMousePos(static_cast<int>(io.MousePos.x),
                                            static_cast<int>(io.MousePos.y));

--- a/imgui-SFML.cpp
+++ b/imgui-SFML.cpp
@@ -177,11 +177,9 @@ struct WindowContext {
 
     bool windowHasFocus;
     bool mouseMoved{false};
-    bool mousePressed[3] = {false};
     ImGuiMouseCursor lastCursor{ImGuiMouseCursor_COUNT};
     bool windowIsHovered = {false};
 
-    bool touchDown[3] = {false};
     sf::Vector2i touchPos;
 
     unsigned int joystickId{getConnectedJoystickId()};
@@ -340,11 +338,13 @@ void ProcessEvent(const sf::Event& event) {
         case sf::Event::MouseButtonPressed: // fall-through
         case sf::Event::MouseButtonReleased: {
             const int button = event.mouseButton.button;
-            if (button >= 0 && button < 3) {
-                if (event.type == sf::Event::MouseButtonPressed) {
-                    s_currWindowCtx->mousePressed[event.mouseButton.button] = true;
+            if (button >= 0 && button < 3)
+                {
+                if (event.type == sf::Event::MouseButtonPressed)
+                {
                     io.AddMouseButtonEvent(button, true);
-                } else {
+                } else
+                {
                     io.AddMouseButtonEvent(button, false);
                 }
             }
@@ -352,10 +352,6 @@ void ProcessEvent(const sf::Event& event) {
         case sf::Event::TouchBegan: // fall-through
         case sf::Event::TouchEnded: {
             s_currWindowCtx->mouseMoved = false;
-            const unsigned int button = event.touch.finger;
-            if (event.type == sf::Event::TouchBegan && button < 3) {
-                s_currWindowCtx->touchDown[event.touch.finger] = true;
-            }
         } break;
         case sf::Event::KeyPressed: // fall-through
         case sf::Event::KeyReleased: {
@@ -455,13 +451,6 @@ void Update(const sf::Vector2i& mousePos, const sf::Vector2f& displaySize, sf::T
             sf::Mouse::setPosition(newMousePos);
         } else {
             io.MousePos = ImVec2(static_cast<float>(mousePos.x), static_cast<float>(mousePos.y));
-        }
-        for (unsigned int i = 0; i < 3; i++) {
-            io.MouseDown[i] = s_currWindowCtx->touchDown[i] || sf::Touch::isDown(i) ||
-                              s_currWindowCtx->mousePressed[i] ||
-                              sf::Mouse::isButtonPressed((sf::Mouse::Button)i);
-            s_currWindowCtx->mousePressed[i] = false;
-            s_currWindowCtx->touchDown[i] = false;
         }
     }
 

--- a/imgui-SFML.cpp
+++ b/imgui-SFML.cpp
@@ -328,7 +328,7 @@ void ProcessEvent(const sf::Event& event) {
 
         }
     }
-    
+
     if (s_currWindowCtx->windowHasFocus)
     {
         ImGuiIO& io = ImGui::GetIO();
@@ -442,7 +442,8 @@ void Update(const sf::Vector2i& mousePos, const sf::Vector2f& displaySize, sf::T
     io.DisplaySize = ImVec2(displaySize.x, displaySize.y);
     io.DeltaTime = dt.asSeconds();
 
-    if (s_currWindowCtx->windowIsHovered || s_currWindowCtx->windowHasFocus)
+    if (s_currWindowCtx->windowIsHovered ||
+        s_currWindowCtx->windowHasFocus)
     {
         if (io.WantSetMousePos) {
             const sf::Vector2i newMousePos(static_cast<int>(io.MousePos.x),

--- a/imgui-SFML.cpp
+++ b/imgui-SFML.cpp
@@ -295,27 +295,23 @@ void ProcessEvent(const sf::Event& event) {
     assert(s_currWindowCtx && "No current window is set - forgot to call ImGui::SFML::Init?");
     ImGuiIO& io = ImGui::GetIO();
 
-    //if (s_currWindowCtx->windowHasFocus)
-    {
-        switch (event.type) {
-        case sf::Event::Resized:
-            io.DisplaySize =
-                ImVec2(static_cast<float>(event.size.width), static_cast<float>(event.size.height));
-            break;
-        case sf::Event::MouseEntered:
-            s_currWindowCtx->windowIsHovered = true;
-            break;
-        case sf::Event::MouseLeft:
-            s_currWindowCtx->windowIsHovered = false;
-            break;
-            case sf::Event::MouseMoved:
-                io.AddMousePosEvent(static_cast<float>(event.mouseMove.x),
-                                    static_cast<float>(event.mouseMove.y));
-            s_currWindowCtx->mouseMoved = true;
-            break;
-        }
+    switch (event.type) {
+    case sf::Event::Resized:
+        io.DisplaySize =
+            ImVec2(static_cast<float>(event.size.width), static_cast<float>(event.size.height));
+        break;
+    case sf::Event::MouseEntered:
+        s_currWindowCtx->windowIsHovered = true;
+        break;
+    case sf::Event::MouseLeft:
+        s_currWindowCtx->windowIsHovered = false;
+        break;
+        case sf::Event::MouseMoved:
+            io.AddMousePosEvent(static_cast<float>(event.mouseMove.x),
+                                static_cast<float>(event.mouseMove.y));
+        s_currWindowCtx->mouseMoved = true;
+        break;
     }
-    
     
     if (s_currWindowCtx->windowIsHovered) {
         ImGuiIO& io = ImGui::GetIO();

--- a/imgui-SFML.cpp
+++ b/imgui-SFML.cpp
@@ -277,6 +277,7 @@ void SetCurrentWindow(const sf::Window& window) {
     assert(found != s_windowContexts.end() &&
            "Failed to find the window. Forgot to call ImGui::SFML::Init for the window?");
     s_currWindowCtx = found->get();
+    s_currWindowCtx->windowHasFocus = window.hasFocus();
     ImGui::SetCurrentContext(s_currWindowCtx->imContext);
 }
 

--- a/imgui-SFML.cpp
+++ b/imgui-SFML.cpp
@@ -295,7 +295,8 @@ void ProcessEvent(const sf::Event& event) {
     assert(s_currWindowCtx && "No current window is set - forgot to call ImGui::SFML::Init?");
     ImGuiIO& io = ImGui::GetIO();
 
-    if (s_currWindowCtx->windowHasFocus) {
+    //if (s_currWindowCtx->windowHasFocus)
+    {
         switch (event.type) {
         case sf::Event::Resized:
             io.DisplaySize =
@@ -306,6 +307,11 @@ void ProcessEvent(const sf::Event& event) {
             break;
         case sf::Event::MouseLeft:
             s_currWindowCtx->windowIsHovered = false;
+            break;
+            case sf::Event::MouseMoved:
+                io.AddMousePosEvent(static_cast<float>(event.mouseMove.x),
+                                    static_cast<float>(event.mouseMove.y));
+            s_currWindowCtx->mouseMoved = true;
             break;
         }
     }
@@ -323,6 +329,7 @@ void ProcessEvent(const sf::Event& event) {
                 io.MouseWheelH += event.mouseWheelScroll.delta;
             }
             break;
+
         }
     }
     if (s_currWindowCtx->windowHasFocus)
@@ -330,11 +337,6 @@ void ProcessEvent(const sf::Event& event) {
         ImGuiIO& io = ImGui::GetIO();
 
         switch (event.type) {
-        case sf::Event::MouseMoved:
-            io.AddMousePosEvent(static_cast<float>(event.mouseMove.x),
-                                static_cast<float>(event.mouseMove.y));
-            s_currWindowCtx->mouseMoved = true;
-            break;
         case sf::Event::MouseButtonPressed: // fall-through
         case sf::Event::MouseButtonReleased: {
             const int button = event.mouseButton.button;

--- a/imgui-SFML.cpp
+++ b/imgui-SFML.cpp
@@ -307,7 +307,7 @@ void ProcessEvent(const sf::Event& event) {
         s_currWindowCtx->windowIsHovered = false;
         break;
     case sf::Event::MouseMoved:
-		io.AddMousePosEvent(static_cast<float>(event.mouseMove.x),
+        io.AddMousePosEvent(static_cast<float>(event.mouseMove.x),
                             static_cast<float>(event.mouseMove.y));
         s_currWindowCtx->mouseMoved = true;
         break;
@@ -316,7 +316,6 @@ void ProcessEvent(const sf::Event& event) {
     }
 
     if (s_currWindowCtx->windowIsHovered) {
-
         switch (event.type) {
         case sf::Event::MouseWheelScrolled:
             if (event.mouseWheelScroll.wheel == sf::Mouse::VerticalWheel ||

--- a/imgui-SFML.cpp
+++ b/imgui-SFML.cpp
@@ -263,7 +263,7 @@ bool Init(sf::Window& window, const sf::Vector2f& displaySize, bool loadDefaultF
     }
 
     s_currWindowCtx->windowHasFocus = window.hasFocus();
-    // TODO : initialize windowIsHovered
+    // TODO : initialize s_currWindowCtx->windowIsHovered
     return true;
 }
 

--- a/imgui-SFML.cpp
+++ b/imgui-SFML.cpp
@@ -306,13 +306,12 @@ void ProcessEvent(const sf::Event& event) {
     case sf::Event::MouseLeft:
         s_currWindowCtx->windowIsHovered = false;
         break;
-        case sf::Event::MouseMoved:
-            io.AddMousePosEvent(static_cast<float>(event.mouseMove.x),
-                                static_cast<float>(event.mouseMove.y));
+    case sf::Event::MouseMoved:
+        io.AddMousePosEvent(static_cast<float>(event.mouseMove.x), static_cast<float>(event.mouseMove.y));
         s_currWindowCtx->mouseMoved = true;
         break;
-        default:
-            break;
+    default:
+        break;
     }
 
     if (s_currWindowCtx->windowIsHovered) {
@@ -337,8 +336,7 @@ void ProcessEvent(const sf::Event& event) {
         case sf::Event::MouseButtonReleased: {
             const int button = event.mouseButton.button;
             if (button >= 0 && button < 3) {
-                if (event.type == sf::Event::MouseButtonPressed)
-                {
+                if (event.type == sf::Event::MouseButtonPressed) {
                     io.AddMouseButtonEvent(button, true);
                 } else
                 {
@@ -440,8 +438,7 @@ void Update(const sf::Vector2i& mousePos, const sf::Vector2f& displaySize, sf::T
     io.DisplaySize = ImVec2(displaySize.x, displaySize.y);
     io.DeltaTime = dt.asSeconds();
 
-    if (s_currWindowCtx->windowIsHovered ||
-        s_currWindowCtx->windowHasFocus) {
+    if (s_currWindowCtx->windowIsHovered || s_currWindowCtx->windowHasFocus) {
         if (io.WantSetMousePos) {
             const sf::Vector2i newMousePos(static_cast<int>(io.MousePos.x),
                                            static_cast<int>(io.MousePos.y));

--- a/imgui-SFML.cpp
+++ b/imgui-SFML.cpp
@@ -314,7 +314,6 @@ void ProcessEvent(const sf::Event& event) {
     }
     
     if (s_currWindowCtx->windowIsHovered) {
-        ImGuiIO& io = ImGui::GetIO();
 
         switch (event.type) {
         case sf::Event::MouseWheelScrolled:
@@ -331,8 +330,6 @@ void ProcessEvent(const sf::Event& event) {
 
     if (s_currWindowCtx->windowHasFocus)
     {
-        ImGuiIO& io = ImGui::GetIO();
-
         switch (event.type) {
         case sf::Event::MouseButtonPressed: // fall-through
         case sf::Event::MouseButtonReleased: {

--- a/imgui-SFML.cpp
+++ b/imgui-SFML.cpp
@@ -307,7 +307,8 @@ void ProcessEvent(const sf::Event& event) {
         s_currWindowCtx->windowIsHovered = false;
         break;
     case sf::Event::MouseMoved:
-        io.AddMousePosEvent(static_cast<float>(event.mouseMove.x), static_cast<float>(event.mouseMove.y));
+		io.AddMousePosEvent(static_cast<float>(event.mouseMove.x),
+                            static_cast<float>(event.mouseMove.y));
         s_currWindowCtx->mouseMoved = true;
         break;
     default:
@@ -325,8 +326,8 @@ void ProcessEvent(const sf::Event& event) {
                 io.MouseWheelH += event.mouseWheelScroll.delta;
             }
             break;
-            default:
-                break;
+        default:
+            break;
         }
     }
 
@@ -338,8 +339,7 @@ void ProcessEvent(const sf::Event& event) {
             if (button >= 0 && button < 3) {
                 if (event.type == sf::Event::MouseButtonPressed) {
                     io.AddMouseButtonEvent(button, true);
-                } else
-                {
+                } else {
                     io.AddMouseButtonEvent(button, false);
                 }
             }

--- a/imgui-SFML.cpp
+++ b/imgui-SFML.cpp
@@ -328,6 +328,7 @@ void ProcessEvent(const sf::Event& event) {
 
         }
     }
+    
     if (s_currWindowCtx->windowHasFocus)
     {
         ImGuiIO& io = ImGui::GetIO();


### PR DESCRIPTION
- added hovered state
- use event queue instead of querying the mouse position to determine mouse/tap states
- allow scroll wheel events for hovered windows
- Initialize windowHasFocus correctly
- Remove mousePressed / touchDown states