### PR TITLE
Added definitions for ImageButton with explicit ID

### DIFF
--- a/imgui-SFML.cpp
+++ b/imgui-SFML.cpp
@@ -739,6 +739,15 @@ bool ImageButton(const sf::Texture& texture, const sf::Vector2f& size, const int
                               framePadding, toImColor(bgColor), toImColor(tintColor));
 }
 
+IMGUI_SFML_API bool ImageButton(const char* id, const sf::Texture& texture,
+                                const sf::Vector2f& size,
+                                const sf::Color& bgColor, const sf::Color& tintColor) {
+    ImTextureID textureID = convertGLTextureHandleToImTextureID(texture.getNativeHandle());
+
+    return ImGui::ImageButton(id, textureID, ImVec2(size.x, size.y), ImVec2(0, 0), ImVec2(1, 1),
+                              toImColor(bgColor), toImColor(tintColor));
+}
+
 /////////////// Image Button Overloads for sf::RenderTexture
 
 bool ImageButton(const sf::RenderTexture& texture, const int framePadding, const sf::Color& bgColor,
@@ -755,6 +764,18 @@ bool ImageButton(const sf::RenderTexture& texture, const sf::Vector2f& size, con
                               ImVec2(1, 0), // flipped vertically, because textures in
                                             // sf::RenderTexture are stored this way
                               framePadding, toImColor(bgColor), toImColor(tintColor));
+}
+
+IMGUI_SFML_API bool ImageButton(const char* id, const sf::RenderTexture& texture,
+                                const sf::Vector2f& size,
+                                const sf::Color& bgColor, const sf::Color& tintColor) {
+    ImTextureID textureID =
+        convertGLTextureHandleToImTextureID(texture.getTexture().getNativeHandle());
+
+    return ImGui::ImageButton(id, textureID, ImVec2(size.x, size.y), ImVec2(0, 1),
+                              ImVec2(1, 0), // flipped vertically, because textures in
+                                            // sf::RenderTexture are stored this way
+                              toImColor(bgColor), toImColor(tintColor));
 }
 
 /////////////// Image Button Overloads for sf::Sprite
@@ -782,6 +803,26 @@ bool ImageButton(const sf::Sprite& sprite, const sf::Vector2f& size, const int f
 
     ImTextureID textureID = convertGLTextureHandleToImTextureID(texture.getNativeHandle());
     return ImGui::ImageButton(textureID, ImVec2(size.x, size.y), uv0, uv1, framePadding,
+                              toImColor(bgColor), toImColor(tintColor));
+}
+
+IMGUI_SFML_API bool ImageButton(const char* id, const sf::Sprite& sprite, const sf::Vector2f& size,
+                                const sf::Color& bgColor,
+                                const sf::Color& tintColor) {
+    const sf::Texture* texturePtr = sprite.getTexture();
+    // sprite without texture cannot be drawn
+    if (!texturePtr) {
+        return false;
+    }
+    const sf::Texture& texture = *texturePtr;
+    const sf::Vector2f textureSize(texture.getSize());
+    const sf::FloatRect textureRect(sprite.getTextureRect());
+    const ImVec2 uv0(textureRect.left / textureSize.x, textureRect.top / textureSize.y);
+    const ImVec2 uv1((textureRect.left + textureRect.width) / textureSize.x,
+                     (textureRect.top + textureRect.height) / textureSize.y);
+
+    ImTextureID textureID = convertGLTextureHandleToImTextureID(texture.getNativeHandle());
+    return ImGui::ImageButton(id, textureID, ImVec2(size.x, size.y), uv0, uv1,
                               toImColor(bgColor), toImColor(tintColor));
 }
 

--- a/imgui-SFML.h
+++ b/imgui-SFML.h
@@ -113,6 +113,9 @@ IMGUI_SFML_API bool ImageButton(const sf::Texture& texture, const sf::Vector2f& 
                                 int framePadding = -1,
                                 const sf::Color& bgColor = sf::Color::Transparent,
                                 const sf::Color& tintColor = sf::Color::White);
+IMGUI_SFML_API bool ImageButton(const char *id, const sf::Texture& texture, const sf::Vector2f& size,
+                                const sf::Color& bgColor = sf::Color::Transparent,
+                                const sf::Color& tintColor = sf::Color::White);
 
 // ImageButton overloads for sf::RenderTexture
 IMGUI_SFML_API bool ImageButton(const sf::RenderTexture& texture, int framePadding = -1,
@@ -122,6 +125,9 @@ IMGUI_SFML_API bool ImageButton(const sf::RenderTexture& texture, const sf::Vect
                                 int framePadding = -1,
                                 const sf::Color& bgColor = sf::Color::Transparent,
                                 const sf::Color& tintColor = sf::Color::White);
+IMGUI_SFML_API bool ImageButton(const char *id, const sf::RenderTexture& texture, const sf::Vector2f& size,
+                                const sf::Color& bgColor = sf::Color::Transparent,
+                                const sf::Color& tintColor = sf::Color::White);
 
 // ImageButton overloads for sf::Sprite
 IMGUI_SFML_API bool ImageButton(const sf::Sprite& sprite, int framePadding = -1,
@@ -129,6 +135,9 @@ IMGUI_SFML_API bool ImageButton(const sf::Sprite& sprite, int framePadding = -1,
                                 const sf::Color& tintColor = sf::Color::White);
 IMGUI_SFML_API bool ImageButton(const sf::Sprite& sprite, const sf::Vector2f& size,
                                 int framePadding = -1,
+                                const sf::Color& bgColor = sf::Color::Transparent,
+                                const sf::Color& tintColor = sf::Color::White);
+IMGUI_SFML_API bool ImageButton(const char* id, const sf::Sprite& sprite, const sf::Vector2f& size,
                                 const sf::Color& bgColor = sf::Color::Transparent,
                                 const sf::Color& tintColor = sf::Color::White);
 


### PR DESCRIPTION
Hello!

I've added support for the new definitions of ImGui::ImageButton that support explicitely setting the id of the widget.
This feature was [added in ImGui v1.89](https://github.com/ocornut/imgui/issues/5533) and wasn't implemented in ImGui-SFML as far as I was aware.

Please give any feedback if something is wrong. Thanks :)