### PR TITLE
Fix forward declaration of `sf::Event`

### DIFF
--- a/imgui-SFML.h
+++ b/imgui-SFML.h
@@ -10,7 +10,7 @@
 #include "imgui-SFML_export.h"
 
 namespace sf {
-struct Event;
+class Event;
 class RenderTarget;
 class RenderTexture;
 class RenderWindow;


### PR DESCRIPTION
https://github.com/SFML/SFML/pull/2766 changed `sf::Event` from a `struct` to a `class`.