### PR TITLE
Fix for removed Event Inheritance

### DIFF
--- a/examples/minimal/main.cpp
+++ b/examples/minimal/main.cpp
@@ -15,9 +15,9 @@ int main() {
     sf::Clock deltaClock;
     while (window.isOpen()) {
         while (const auto event = window.pollEvent()) {
-            ImGui::SFML::ProcessEvent(window, event);
+            ImGui::SFML::ProcessEvent(window, *event);
 
-            if (event.is<sf::Event::Closed>()) {
+            if (event->is<sf::Event::Closed>()) {
                 window.close();
             }
         }

--- a/examples/multiple_windows/main.cpp
+++ b/examples/multiple_windows/main.cpp
@@ -17,8 +17,8 @@ int main() {
     while (window.isOpen()) {
         // Main window event processing
         while (const auto event = window.pollEvent()) {
-            ImGui::SFML::ProcessEvent(window, event);
-            if (event.is<sf::Event::Closed>()) {
+            ImGui::SFML::ProcessEvent(window, *event);
+            if (event->is<sf::Event::Closed>()) {
                 if (childWindow.isOpen()) {
                     childWindow.close();
                 }
@@ -31,8 +31,8 @@ int main() {
         // Child window event processing
         if (childWindow.isOpen()) {
             while (const auto event = childWindow.pollEvent()) {
-                ImGui::SFML::ProcessEvent(childWindow, event);
-                if (event.is<sf::Event::Closed>()) {
+                ImGui::SFML::ProcessEvent(childWindow, *event);
+                if (event->is<sf::Event::Closed>()) {
                     childWindow.close();
                     ImGui::SFML::Shutdown(childWindow);
                 }

--- a/imgui-SFML.cpp
+++ b/imgui-SFML.cpp
@@ -321,7 +321,7 @@ void ProcessEvent(const sf::Window& window, const sf::Event& event) {
                 io.AddMouseWheelEvent(mouseWheelScrolled->delta, 0);
             }
         }
-        const auto handleKeyChanged = [&io](const sf::Event::KeyChanged& keyChanged, bool down) {
+        const auto handleKeyChanged = [&io](const auto& keyChanged, bool down) {
             const ImGuiKey mod = keycodeToImGuiMod(keyChanged.code);
             // The modifier booleans are not reliable when it's the modifier
             // itself that's being pressed. Detect these presses directly.


### PR DESCRIPTION
Event inheritance was removed in SFML3. I can also split the lambda into two if that is preferred over the auto parameter.