### PR TITLE
Fix ImTextureID type

### DIFF
--- a/imgui-SFML.cpp
+++ b/imgui-SFML.cpp
@@ -894,7 +894,7 @@ SpriteTextureData getSpriteTextureData(const sf::Sprite& sprite)
 
 ImTextureID convertGLTextureHandleToImTextureID(GLuint glTextureHandle)
 {
-    ImTextureID textureID = nullptr;
+    ImTextureID textureID = 0;
     std::memcpy(&textureID, &glTextureHandle, sizeof(GLuint));
     return textureID;
 }

--- a/imgui-SFML.cpp
+++ b/imgui-SFML.cpp
@@ -894,7 +894,7 @@ SpriteTextureData getSpriteTextureData(const sf::Sprite& sprite)
 
 ImTextureID convertGLTextureHandleToImTextureID(GLuint glTextureHandle)
 {
-    ImTextureID textureID = 0;
+    ImTextureID textureID{};
     std::memcpy(&textureID, &glTextureHandle, sizeof(GLuint));
     return textureID;
 }


### PR DESCRIPTION
Hello !

I just wanted to report an issue with latest ImGUI. More specifically
https://github.com/ocornut/imgui/commit/92b94980c69ff3d3d7f5dc30c1c19abfb72db47e

I do know that my current solution means older ImGUI version wouldn't work anymore so I'm wondering what would be the best solution in your opinion (Check the type of ImTextureID and assign it accordingly ? Force the type of ImTextureID to be void* ?)

Thanks in advance