### PR TITLE
Remove use of obsolete ImGui functions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,7 +50,7 @@ jobs:
       with:
         repository: ocornut/imgui
         path: imgui
-        ref: v1.89
+        ref: v1.91.1
 
     - name: Checkout SFML
       uses: actions/checkout@v4

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -38,7 +38,7 @@ if(NOT IMGUI_DIR)
 endif()
 
 # This uses FindImGui.cmake provided in ImGui-SFML repo for now
-find_package(ImGui 1.89 REQUIRED)
+find_package(ImGui 1.91.1 REQUIRED)
 
 # These headers will be installed alongside ImGui-SFML
 set(IMGUI_PUBLIC_HEADERS

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Dependencies
 -----
 
 * [SFML](https://github.com/SFML/SFML) >= 2.5.0
-* [Dear ImGui](https://github.com/ocornut/imgui) >= 1.89
+* [Dear ImGui](https://github.com/ocornut/imgui) >= 1.91.1
 
 Contributing
 -----

--- a/imgui-SFML.cpp
+++ b/imgui-SFML.cpp
@@ -590,24 +590,22 @@ void SetJoystickMapping(int key, unsigned int joystickButton) {
     // For partial backwards compatibility, also expect some ImGuiNavInput_* values.
     ImGuiKey finalKey{};
     switch (key) {
-    case ImGuiNavInput_Activate:
+    case ImGuiKey_GamepadFaceDown:
         finalKey = ImGuiKey_GamepadFaceDown;
         break;
-    case ImGuiNavInput_Cancel:
+    case ImGuiKey_GamepadFaceRight:
         finalKey = ImGuiKey_GamepadFaceRight;
         break;
-    case ImGuiNavInput_Input:
+    case ImGuiKey_GamepadFaceUp:
         finalKey = ImGuiKey_GamepadFaceUp;
         break;
-    case ImGuiNavInput_Menu:
+    case ImGuiKey_GamepadFaceLeft:
         finalKey = ImGuiKey_GamepadFaceLeft;
         break;
-    case ImGuiNavInput_FocusPrev:
-    case ImGuiNavInput_TweakSlow:
+    case ImGuiKey_GamepadL1:
         finalKey = ImGuiKey_GamepadL1;
         break;
-    case ImGuiNavInput_FocusNext:
-    case ImGuiNavInput_TweakFast:
+    case ImGuiKey_GamepadR1:
         finalKey = ImGuiKey_GamepadR1;
         break;
     default:
@@ -920,11 +918,11 @@ void RenderDrawLists(ImDrawData* draw_data) {
         const ImDrawVert* vtx_buffer = cmd_list->VtxBuffer.Data;
         const ImDrawIdx* idx_buffer = cmd_list->IdxBuffer.Data;
         glVertexPointer(2, GL_FLOAT, sizeof(ImDrawVert),
-                        (const GLvoid*)((const char*)vtx_buffer + IM_OFFSETOF(ImDrawVert, pos)));
+                        (const GLvoid*)((const char*)vtx_buffer + offsetof(ImDrawVert, pos)));
         glTexCoordPointer(2, GL_FLOAT, sizeof(ImDrawVert),
-                          (const GLvoid*)((const char*)vtx_buffer + IM_OFFSETOF(ImDrawVert, uv)));
+                          (const GLvoid*)((const char*)vtx_buffer + offsetof(ImDrawVert, uv)));
         glColorPointer(4, GL_UNSIGNED_BYTE, sizeof(ImDrawVert),
-                       (const GLvoid*)((const char*)vtx_buffer + IM_OFFSETOF(ImDrawVert, col)));
+                       (const GLvoid*)((const char*)vtx_buffer + offsetof(ImDrawVert, col)));
 
         for (int cmd_i = 0; cmd_i < cmd_list->CmdBuffer.Size; cmd_i++) {
             const ImDrawCmd* pcmd = &cmd_list->CmdBuffer[cmd_i];

--- a/imgui-SFML.cpp
+++ b/imgui-SFML.cpp
@@ -138,8 +138,8 @@ void updateJoystickDPadState(ImGuiIO& io);
 void updateJoystickAxisState(ImGuiIO& io);
 
 // clipboard functions
-void setClipboardText(void* userData, const char* text);
-const char* getClipboardText(void* userData);
+void setClipboardText(ImGuiContext* /*ctx*/, const char* text);
+const char* getClipboardText(ImGuiContext* /*ctx*/);
 std::string s_clipboardText;
 
 // mouse cursors
@@ -229,6 +229,7 @@ bool Init(sf::Window& window, const sf::Vector2f& displaySize, bool loadDefaultF
     ImGui::SetCurrentContext(s_currWindowCtx->imContext);
 
     ImGuiIO& io = ImGui::GetIO();
+    ImGuiPlatformIO& platform_io = ImGui::GetPlatformIO();
 
     // tell ImGui which features we support
     io.BackendFlags |= ImGuiBackendFlags_HasGamepad;
@@ -244,8 +245,8 @@ bool Init(sf::Window& window, const sf::Vector2f& displaySize, bool loadDefaultF
     io.DisplaySize = ImVec2(displaySize.x, displaySize.y);
 
     // clipboard
-    io.SetClipboardTextFn = setClipboardText;
-    io.GetClipboardTextFn = getClipboardText;
+    platform_io.Platform_SetClipboardTextFn = setClipboardText;
+    platform_io.Platform_GetClipboardTextFn = getClipboardText;
 
     // load mouse cursors
     loadMouseCursor(ImGuiMouseCursor_Arrow, sf::Cursor::Arrow);
@@ -1092,11 +1093,11 @@ void updateJoystickAxisState(ImGuiIO& io) {
                        s_currWindowCtx->rTriggerInfo.threshold, 100, false);
 }
 
-void setClipboardText(void* /*userData*/, const char* text) {
+void setClipboardText(ImGuiContext* /*ctx*/, const char* text) {
     sf::Clipboard::setString(sf::String::fromUtf8(text, text + std::strlen(text)));
 }
 
-const char* getClipboardText(void* /*userData*/) {
+const char* getClipboardText(ImGuiContext* /*ctx*/) {
     std::basic_string<std::uint8_t> tmp = sf::Clipboard::getString().toUtf8();
     s_clipboardText.assign(tmp.begin(), tmp.end());
     return s_clipboardText.c_str();

--- a/imgui-SFML.cpp
+++ b/imgui-SFML.cpp
@@ -342,10 +342,10 @@ void ProcessEvent(const sf::Event& event) {
             if (mod != ImGuiKey_None) {
                 io.AddKeyEvent(mod, down);
             } else {
-                io.AddKeyEvent(ImGuiKey_ModCtrl, event.key.control);
-                io.AddKeyEvent(ImGuiKey_ModShift, event.key.shift);
-                io.AddKeyEvent(ImGuiKey_ModAlt, event.key.alt);
-                io.AddKeyEvent(ImGuiKey_ModSuper, event.key.system);
+                io.AddKeyEvent(ImGuiMod_Ctrl, event.key.control);
+                io.AddKeyEvent(ImGuiMod_Shift, event.key.shift);
+                io.AddKeyEvent(ImGuiMod_Alt, event.key.alt);
+                io.AddKeyEvent(ImGuiMod_Super, event.key.system);
             }
 
             const ImGuiKey key = keycodeToImGuiKey(event.key.code);
@@ -1341,16 +1341,16 @@ ImGuiKey keycodeToImGuiMod(sf::Keyboard::Key code) {
     switch (code) {
     case sf::Keyboard::LControl:
     case sf::Keyboard::RControl:
-        return ImGuiKey_ModCtrl;
+        return ImGuiMod_Ctrl;
     case sf::Keyboard::LShift:
     case sf::Keyboard::RShift:
-        return ImGuiKey_ModShift;
+        return ImGuiMod_Shift;
     case sf::Keyboard::LAlt:
     case sf::Keyboard::RAlt:
-        return ImGuiKey_ModAlt;
+        return ImGuiMod_Alt;
     case sf::Keyboard::LSystem:
     case sf::Keyboard::RSystem:
-        return ImGuiKey_ModSuper;
+        return ImGuiMod_Super;
     default:
         break;
     }


### PR DESCRIPTION
This PR contains migration commits to allow imgui-sfml to be compiled with the flag IMGUI_DISABLE_OBSOLETE_FUNCTIONS.
I put them in the order of imgui updates for easier integration if needed.

Those commits will force the project to raise the minimum imgui version supported, so it may not be welcome right now.
However, it can be useful for people willing to enforce this compilation flag on their projects.
I am not familiar with cmake and thus I am unable to tweak/test the version settings on this part.

Please feel free to use those commits as you see fit, either by cherry-picking them at a later time, or by merging them into a different branch.

This PR is tied to this ticket : https://github.com/SFML/imgui-sfml/issues/301