### PR TITLE
Remove use of obsolete ImGui functions - v1.89

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -92,6 +92,7 @@ jobs:
           -DIMGUI_SFML_BUILD_EXAMPLES=ON \
           -DIMGUI_SFML_BUILD_TESTING=ON \
           -DIMGUI_SFML_ENABLE_WARNINGS=ON \
+          -DIMGUI_SFML_DISABLE_OBSOLETE_FUNCTIONS=ON \
           ${{matrix.platform.flags}} \
           ${{matrix.config.flags}}
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,6 +4,7 @@ project(imgui_sfml VERSION 2.6 LANGUAGES CXX)
 option(IMGUI_SFML_FIND_SFML "Use find_package to find SFML" ON)
 option(IMGUI_SFML_IMGUI_DEMO "Build imgui_demo.cpp" ON)
 option(IMGUI_SFML_ENABLE_WARNINGS "Enable compiler warnings" OFF)
+option(IMGUI_SFML_DISABLE_OBSOLETE_FUNCTIONS "Disable obsolete ImGui functions" OFF)
 
 # If you want to use your own user config when compiling ImGui, please set the following variables
 # For example, if you have your config in /path/to/dir/with/config/myconfig.h, set the variables as follows:
@@ -83,6 +84,9 @@ if(BUILD_SHARED_LIBS)
   target_compile_definitions(ImGui-SFML PRIVATE IMGUI_SFML_SHARED_LIB)
   set_target_properties(ImGui-SFML PROPERTIES DEFINE_SYMBOL "IMGUI_SFML_EXPORTS")
   set_target_properties(ImGui-SFML PROPERTIES DEBUG_POSTFIX "_d")
+endif()
+if(IMGUI_SFML_DISABLE_OBSOLETE_FUNCTIONS)
+  target_compile_definitions(ImGui-SFML PUBLIC IMGUI_DISABLE_OBSOLETE_FUNCTIONS)
 endif()
 
 # Add compiler warnings

--- a/imgui-SFML.cpp
+++ b/imgui-SFML.cpp
@@ -342,10 +342,10 @@ void ProcessEvent(const sf::Event& event) {
             if (mod != ImGuiKey_None) {
                 io.AddKeyEvent(mod, down);
             } else {
-                io.AddKeyEvent(ImGuiKey_ModCtrl, event.key.control);
-                io.AddKeyEvent(ImGuiKey_ModShift, event.key.shift);
-                io.AddKeyEvent(ImGuiKey_ModAlt, event.key.alt);
-                io.AddKeyEvent(ImGuiKey_ModSuper, event.key.system);
+                io.AddKeyEvent(ImGuiMod_Ctrl, event.key.control);
+                io.AddKeyEvent(ImGuiMod_Shift, event.key.shift);
+                io.AddKeyEvent(ImGuiMod_Alt, event.key.alt);
+                io.AddKeyEvent(ImGuiMod_Super, event.key.system);
             }
 
             const ImGuiKey key = keycodeToImGuiKey(event.key.code);
@@ -1341,16 +1341,16 @@ ImGuiKey keycodeToImGuiMod(sf::Keyboard::Key code) {
     switch (code) {
     case sf::Keyboard::LControl:
     case sf::Keyboard::RControl:
-        return ImGuiKey_ModCtrl;
+        return ImGuiMod_Ctrl;
     case sf::Keyboard::LShift:
     case sf::Keyboard::RShift:
-        return ImGuiKey_ModShift;
+        return ImGuiMod_Shift;
     case sf::Keyboard::LAlt:
     case sf::Keyboard::RAlt:
-        return ImGuiKey_ModAlt;
+        return ImGuiMod_Alt;
     case sf::Keyboard::LSystem:
     case sf::Keyboard::RSystem:
-        return ImGuiKey_ModSuper;
+        return ImGuiMod_Super;
     default:
         break;
     }


### PR DESCRIPTION
This PR contains a migration commit to allow imgui-sfml to be compiled with the flag IMGUI_DISABLE_OBSOLETE_FUNCTIONS.
Target imgui version : 1.89