### PR TITLE
Fix for imgui 1.91.5 (clean some deprecated API calls)

### DIFF
--- a/imgui-SFML.cpp
+++ b/imgui-SFML.cpp
@@ -590,24 +590,22 @@ void SetJoystickMapping(int key, unsigned int joystickButton) {
     // For partial backwards compatibility, also expect some ImGuiNavInput_* values.
     ImGuiKey finalKey{};
     switch (key) {
-    case ImGuiNavInput_Activate:
+    case ImGuiKey_GamepadFaceDown:
         finalKey = ImGuiKey_GamepadFaceDown;
         break;
-    case ImGuiNavInput_Cancel:
+    case ImGuiKey_GamepadFaceRight:
         finalKey = ImGuiKey_GamepadFaceRight;
         break;
-    case ImGuiNavInput_Input:
+    case ImGuiKey_GamepadFaceUp:
         finalKey = ImGuiKey_GamepadFaceUp;
         break;
-    case ImGuiNavInput_Menu:
+    case ImGuiKey_GamepadFaceLeft:
         finalKey = ImGuiKey_GamepadFaceLeft;
         break;
-    case ImGuiNavInput_FocusPrev:
-    case ImGuiNavInput_TweakSlow:
+    case ImGuiKey_GamepadL1:
         finalKey = ImGuiKey_GamepadL1;
         break;
-    case ImGuiNavInput_FocusNext:
-    case ImGuiNavInput_TweakFast:
+    case ImGuiKey_GamepadR1:
         finalKey = ImGuiKey_GamepadR1;
         break;
     default:
@@ -920,11 +918,11 @@ void RenderDrawLists(ImDrawData* draw_data) {
         const ImDrawVert* vtx_buffer = cmd_list->VtxBuffer.Data;
         const ImDrawIdx* idx_buffer = cmd_list->IdxBuffer.Data;
         glVertexPointer(2, GL_FLOAT, sizeof(ImDrawVert),
-                        (const GLvoid*)((const char*)vtx_buffer + IM_OFFSETOF(ImDrawVert, pos)));
+                        (const GLvoid*)((const char*)vtx_buffer + offsetof(ImDrawVert, pos)));
         glTexCoordPointer(2, GL_FLOAT, sizeof(ImDrawVert),
-                          (const GLvoid*)((const char*)vtx_buffer + IM_OFFSETOF(ImDrawVert, uv)));
+                          (const GLvoid*)((const char*)vtx_buffer + offsetof(ImDrawVert, uv)));
         glColorPointer(4, GL_UNSIGNED_BYTE, sizeof(ImDrawVert),
-                       (const GLvoid*)((const char*)vtx_buffer + IM_OFFSETOF(ImDrawVert, col)));
+                       (const GLvoid*)((const char*)vtx_buffer + offsetof(ImDrawVert, col)));
 
         for (int cmd_i = 0; cmd_i < cmd_list->CmdBuffer.Size; cmd_i++) {
             const ImDrawCmd* pcmd = &cmd_list->CmdBuffer[cmd_i];

--- a/imgui-SFML.cpp
+++ b/imgui-SFML.cpp
@@ -586,7 +586,8 @@ void SetJoystickRTriggerThreshold(float threshold) {
 
 void SetJoystickMapping(int key, unsigned int joystickButton) {
     assert(s_currWindowCtx);
-    assert(key >= ImGuiKey_NamedKey_BEGIN && key < ImGuiKey_NamedKey_END);
+    assert(key >= ImGuiKey_NamedKey_BEGIN);
+    assert(key < ImGuiKey_NamedKey_END);
     assert(joystickButton < sf::Joystick::ButtonCount);
     s_currWindowCtx->joystickMapping[joystickButton] = static_cast<ImGuiKey>(key);
 }

--- a/imgui-SFML.cpp
+++ b/imgui-SFML.cpp
@@ -586,34 +586,9 @@ void SetJoystickRTriggerThreshold(float threshold) {
 
 void SetJoystickMapping(int key, unsigned int joystickButton) {
     assert(s_currWindowCtx);
-    // This function now expects ImGuiKey_* values.
-    // For partial backwards compatibility, also expect some ImGuiNavInput_* values.
-    ImGuiKey finalKey{};
-    switch (key) {
-    case ImGuiKey_GamepadFaceDown:
-        finalKey = ImGuiKey_GamepadFaceDown;
-        break;
-    case ImGuiKey_GamepadFaceRight:
-        finalKey = ImGuiKey_GamepadFaceRight;
-        break;
-    case ImGuiKey_GamepadFaceUp:
-        finalKey = ImGuiKey_GamepadFaceUp;
-        break;
-    case ImGuiKey_GamepadFaceLeft:
-        finalKey = ImGuiKey_GamepadFaceLeft;
-        break;
-    case ImGuiKey_GamepadL1:
-        finalKey = ImGuiKey_GamepadL1;
-        break;
-    case ImGuiKey_GamepadR1:
-        finalKey = ImGuiKey_GamepadR1;
-        break;
-    default:
-        assert(key >= ImGuiKey_NamedKey_BEGIN && key < ImGuiKey_NamedKey_END);
-        finalKey = static_cast<ImGuiKey>(key);
-    }
+    assert(key >= ImGuiKey_NamedKey_BEGIN && key < ImGuiKey_NamedKey_END);
     assert(joystickButton < sf::Joystick::ButtonCount);
-    s_currWindowCtx->joystickMapping[joystickButton] = finalKey;
+    s_currWindowCtx->joystickMapping[joystickButton] = static_cast<ImGuiKey>(key);
 }
 
 void SetDPadXAxis(sf::Joystick::Axis dPadXAxis, bool inverted) {


### PR DESCRIPTION
This PR contains fixes for imgui 1.90 when using the IMGUI_DISABLE_OBSOLETE_FUNCTIONS flag.
Associated discussions : https://github.com/SFML/imgui-sfml/issues/301

For this PR to be finalized, the minimum supported version will have to be updated from 1.89 to 1.90.
The supported versions with the flag enabled would range from 1.90 (November 2023) to 1.91.0 (July 2024)
EDIT: It appears that the minimum version supported is unchanged, no need to update it.

To make the change on the CI settings and docs, I guess I should wait for the imgui_version branch to be merged back into the 2.6.x branch ?

PS: if several tests are implemented for different imgui targets, it could be interesting to also target the -docking tags associated with each imgui version.
(EDIT: not sure if anything could break on those branches though).