### PR TITLE
Updated obsoleted functions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,8 +37,8 @@ jobs:
         - { name: Release }
         - { name: Debug }
         imgui:
-        - { version: 1.89, flags: -DIMGUI_SFML_DISABLE_OBSOLETE_FUNCTIONS=ON }
-        - { version: 1.91.5 }
+        - { version: 1.91.1 }
+        - { version: 1.91.6, flags: -DIMGUI_SFML_DISABLE_OBSOLETE_FUNCTIONS=ON }
 
     steps:
     - name: Get CMake and Ninja

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,8 +37,8 @@ jobs:
         - { name: Release }
         - { name: Debug }
         imgui:
-        - { version: 1.91.1 }
-        - { version: 1.91.6, flags: -DIMGUI_SFML_DISABLE_OBSOLETE_FUNCTIONS=ON }
+        - { version: 1.91.1, flags: -DIMGUI_SFML_DISABLE_OBSOLETE_FUNCTIONS=ON }
+        - { version: 1.91.6 }
 
     steps:
     - name: Get CMake and Ninja

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -38,7 +38,7 @@ if(NOT IMGUI_DIR)
 endif()
 
 # This uses FindImGui.cmake provided in ImGui-SFML repo for now
-find_package(ImGui 1.89 REQUIRED)
+find_package(ImGui 1.91.1 REQUIRED)
 
 # These headers will be installed alongside ImGui-SFML
 set(IMGUI_PUBLIC_HEADERS

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Dependencies
 -----
 
 * [SFML](https://github.com/SFML/SFML) >= 3.0.0
-* [Dear ImGui](https://github.com/ocornut/imgui) >= 1.89
+* [Dear ImGui](https://github.com/ocornut/imgui) >= 1.91.1
 
 Contributing
 -----

--- a/imgui-SFML.cpp
+++ b/imgui-SFML.cpp
@@ -200,12 +200,12 @@ void updateJoystickDPadState(ImGuiIO& io);
 void updateJoystickAxisState(ImGuiIO& io);
 
 // clipboard functions
-void setClipboardText(void* /*userData*/, const char* text)
+void setClipboardText(ImGuiContext* /*ctx*/, const char* text)
 {
     sf::Clipboard::setString(sf::String::fromUtf8(text, text + std::strlen(text)));
 }
 
-[[nodiscard]] const char* getClipboardText(void* /*userData*/)
+[[nodiscard]] const char* getClipboardText(ImGuiContext* /*ctx*/)
 {
     static std::string s_clipboardText;
 
@@ -307,6 +307,7 @@ bool Init(sf::Window& window, const sf::Vector2f& displaySize, bool loadDefaultF
     ImGui::SetCurrentContext(s_currWindowCtx->imContext);
 
     ImGuiIO& io = ImGui::GetIO();
+    ImGuiPlatformIO& platform_io = ImGui::GetPlatformIO();
 
     // tell ImGui which features we support
     io.BackendFlags |= ImGuiBackendFlags_HasGamepad;
@@ -322,8 +323,8 @@ bool Init(sf::Window& window, const sf::Vector2f& displaySize, bool loadDefaultF
     io.DisplaySize = toImVec2(displaySize);
 
     // clipboard
-    io.SetClipboardTextFn = setClipboardText;
-    io.GetClipboardTextFn = getClipboardText;
+    platform_io.Platform_SetClipboardTextFn = setClipboardText;
+    platform_io.Platform_GetClipboardTextFn = getClipboardText;
 
     // load mouse cursors
     const auto loadMouseCursor = [](ImGuiMouseCursor imguiCursorType, sf::Cursor::Type sfmlCursorType)

--- a/imgui-SFML.cpp
+++ b/imgui-SFML.cpp
@@ -306,7 +306,7 @@ bool Init(sf::Window& window, const sf::Vector2f& displaySize, bool loadDefaultF
     s_currWindowCtx = s_windowContexts.emplace_back(std::make_unique<WindowContext>(&window)).get();
     ImGui::SetCurrentContext(s_currWindowCtx->imContext);
 
-    ImGuiIO& io = ImGui::GetIO();
+    ImGuiIO&         io          = ImGui::GetIO();
     ImGuiPlatformIO& platform_io = ImGui::GetPlatformIO();
 
     // tell ImGui which features we support


### PR DESCRIPTION
The members `ImGuiIO::SetClipboardTextFn` and `ImGuiIO::GetClipboardTextFn` have been obsoleted. This pull request uses the new members in `ImGuiPlatformIO`.