### PR TITLE
Ensure `OpenGL::GL` target is found when using config module

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -133,7 +133,10 @@ install(TARGETS ImGui-SFML
 install(EXPORT ImGui-SFML
   DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/ImGui-SFML
   NAMESPACE ImGui-SFML::
-  FILE ImGui-SFMLConfig.cmake
+)
+
+install(FILES ${PROJECT_SOURCE_DIR}/cmake/ImGui-SFMLConfig.cmake
+        DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/ImGui-SFML
 )
 
 # Stop configuration if being consumed by a higher level project

--- a/cmake/ImGui-SFMLConfig.cmake
+++ b/cmake/ImGui-SFMLConfig.cmake
@@ -1,0 +1,5 @@
+include(CMakeFindDependencyMacro)
+find_dependency(OpenGL)
+find_dependency(SFML COMPONENTS Graphics)
+
+include(${CMAKE_CURRENT_LIST_DIR}/ImGui-SFML.cmake)


### PR DESCRIPTION
Fixing a bug first reported in https://github.com/microsoft/vcpkg/issues/44123 and fixed in https://github.com/microsoft/vcpkg/pull/44203. The proper thing to do would be write install interface tests like SFML has. That would systematically prevent issues like this in the future.