### PR TITLE
Fixed SetLTriggerAxis to set the correct internal variable

### DIFF
--- a/imgui-SFML.cpp
+++ b/imgui-SFML.cpp
@@ -754,7 +754,7 @@ void SetRStickYAxis(sf::Joystick::Axis rStickYAxis, bool inverted)
 void SetLTriggerAxis(sf::Joystick::Axis lTriggerAxis)
 {
     assert(s_currWindowCtx);
-    s_currWindowCtx->rTriggerInfo.axis = lTriggerAxis;
+    s_currWindowCtx->lTriggerInfo.axis = lTriggerAxis;
 }
 
 void SetRTriggerAxis(sf::Joystick::Axis rTriggerAxis)


### PR DESCRIPTION
Fixed SetLTriggerAxis to set the correct internal variable. See Issue #323