### PR TITLE
Replace direct TextureId access with GetTexID()

### DIFF
--- a/imgui-SFML.cpp
+++ b/imgui-SFML.cpp
@@ -1040,7 +1040,7 @@ void RenderDrawLists(ImDrawData* draw_data)
                               (int)(clip_rect.w - clip_rect.y));
 
                     // Bind texture, Draw
-                    const GLuint textureHandle = convertImTextureIDToGLTextureHandle(pcmd->TextureId);
+                    const GLuint textureHandle = convertImTextureIDToGLTextureHandle(pcmd->GetTexID());
                     glBindTexture(GL_TEXTURE_2D, textureHandle);
                     glDrawElements(GL_TRIANGLES,
                                    (GLsizei)pcmd->ElemCount,


### PR DESCRIPTION
In ImGui v1.92.0 and newer, direct access to ImDrawCmd::TextureId is deprecated and replaced by the GetTexID() accessor.