### PR TITLE
Fix Windows CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ jobs:
       matrix:
         platform:
         - { name: Windows MSVC,    os: windows-2025 }
-        - { name: Windows ClangCL, os: windows-2025, flags: -T ClangCL }
+        - { name: Windows ClangCL, os: windows-2025, flags: -GNinja -DCMAKE_C_COMPILER=clang-cl -DCMAKE_CXX_COMPILER=clang-cl }
         - { name: Windows Clang,   os: windows-2025, flags: -GNinja -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++ }
         - { name: Linux GCC,       os: ubuntu-22.04, flags: -GNinja }
         - { name: Linux Clang,     os: ubuntu-22.04, flags: -GNinja -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++ }
@@ -52,6 +52,12 @@ jobs:
       run: |
         sudo apt update
         sudo apt install llvm xorg-dev libxrandr-dev libxcursor-dev libudev-dev libflac-dev libvorbis-dev libgl1-mesa-dev libegl1-mesa-dev
+
+    - name: Setup Visual Studio Developer Command Prompt
+      if: runner.os == 'Windows'
+      uses: TheMrMilchmann/setup-msvc-dev@v4
+      with:
+        arch: x64
 
     - name: Checkout ImGui
       uses: actions/checkout@v4


### PR DESCRIPTION
Changes in the `windows-2025` image caused Windows CI jobs to start failing, there was two problems to be fixed:
- MSVC builds started complaining that `nmake` couldn't be found, this was fixed by adding a build step that sets the environment variables you'd get if you ran the VS Developer Command Prompt
- ClangCL builds were complaining that the NMake generator doesn't support toolset specification, fixed by changing the generator to Ninja and explicitly passing `DCMAKE_C/CXX_COMPILER` flags instead of `-T`